### PR TITLE
Fix Patterns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Change Log
 
+## 0.1.1 - 2022-06-01
+- Fix the following potential Pattern-related errors:
+  - cyclic patterns
+  - `alternates` that contain `optional` or `zeroOrMore` sub-patterns
+  - `sequence` and `alternates` that contain only one sub-pattern
+
 ## 0.1.0 - 2022-05-20
 - Initial alpha release.
-

--- a/README.md
+++ b/README.md
@@ -24,3 +24,5 @@ Options not provided in the arg map use the values of `default-args`. The follow
 | `:num-statement-templates` | The number of Statement Templates per Profile. | `5` |
 | `:num-patterns` | The number of Patterns per Profile. | `5` |
 | `:max-iris` | The maximum number of IRIs that can be generated in a single IRI array (e.g. for `broader` and `narrower`). | `5` |
+
+All IRIs will point to other IRIs in the Profile cosmos to the extent specified by the xAPI Profile spec; the exception is with Patterns, which only point to sub-Patterns in the same Profile version (though they can point to any Template in the cosmos).

--- a/deps.edn
+++ b/deps.edn
@@ -14,7 +14,7 @@
                             :git/sha "dfb30dd"}
                            com.yetanalytics/project-pan
                            {:git/url "https://github.com/yetanalytics/project-pan.git"
-                            :git/sha "7a4493ddee76cb333385bef67928ff14ba7973a3"
+                            :git/sha "8faf3da17b082fe7f9c4b02321278ee81b721409"
                             :exclusions [org.clojure/clojure
                                          org.clojure/clojurescript]}}}
   :run-clj  {:exec-fn   cognitect.test-runner.api/test

--- a/deps.edn
+++ b/deps.edn
@@ -14,7 +14,7 @@
                             :git/sha "dfb30dd"}
                            com.yetanalytics/project-pan
                            {:git/url "https://github.com/yetanalytics/project-pan.git"
-                            :git/sha "e2fdba72210dbb97a9fbaa6bc3ed65d7c6657e9c"
+                            :git/sha "7a4493ddee76cb333385bef67928ff14ba7973a3"
                             :exclusions [org.clojure/clojure
                                          org.clojure/clojurescript]}}}
   :run-clj  {:exec-fn   cognitect.test-runner.api/test

--- a/src/main/com/yetanalytics/poly/profile/pattern.cljc
+++ b/src/main/com/yetanalytics/poly/profile/pattern.cljc
@@ -1,57 +1,142 @@
 (ns com.yetanalytics.poly.profile.pattern
-  (:require [com.yetanalytics.poly.profile.utils.gen :refer [generate-object]]
+  (:require [clojure.set :as cset]
+            [com.yetanalytics.poly.profile.utils.gen :refer [generate-object]]
             [com.yetanalytics.poly.profile.utils.iri :as iri]
             #?@(:cljs [[goog.string :refer [format]]
                        [goog.string.format]])))
 
+(defn update-transitive-closure
+  [trans-closure pattern-id sub-pattern-ids]
+  (let [ancestor-ids (-> trans-closure
+                         (get pattern-id)
+                         (conj pattern-id)
+                         set)]
+    (reduce (fn [m sub-pat-id]
+              (if (contains? m sub-pat-id)
+                (update m sub-pat-id cset/union ancestor-ids)
+                (assoc m sub-pat-id (conj ancestor-ids sub-pat-id))))
+            trans-closure
+            (conj sub-pattern-ids pattern-id))))
 
-(defn- generate-pattern-iri-scalar
-  [prof-num
-   ver-num
-   pattern-num
+(comment
+  (-> {}
+      (update-transitive-closure 0 #{1 2})
+      (update-transitive-closure 1 #{3})
+      (update-transitive-closure 2 #{3}))
+
+  (update-transitive-closure {}
+                             0
+                             #{1}))
+
+(defn- init-scalar-pattern
+  [pattern-base
+   pattern-kw
+   num-profs
+   num-vers
+   num-templates]
+  (assoc pattern-base
+         pattern-kw (first (iri/create-iri-vec "template"
+                                               num-profs
+                                               num-vers
+                                               num-templates
+                                               1
+                                               1))))
+
+(defn- init-coll-pattern
+  [pattern-base
+   pattern-kw
    num-profs
    num-vers
    num-templates
-   num-patterns]
-  (if (= 0 (rand-int 2))
-    (first (iri/create-iri-vec "template"
-                               num-profs
-                               num-vers
-                               num-templates
-                               1))
-    (first (iri/create-iri-vec prof-num
-                               ver-num
-                               pattern-num
-                               "pattern"
-                               num-profs
-                               num-vers
-                               num-patterns
-                               1))))
+   max-iris]
+  (assoc pattern-base
+         pattern-kw (iri/create-iri-vec "template"
+                                        num-profs
+                                        num-vers
+                                        num-templates
+                                        max-iris
+                                        2)))
 
-(defn- generate-pattern-iri-coll
-  [prof-num
+(defn- add-patterns
+  [pattern-vec
+   prof-num
    ver-num
-   pattern-num
-   num-profs
-   num-vers
-   num-templates
    num-patterns
    max-iris]
-  (-> (concat
-       (iri/create-iri-vec "template"
-                           num-profs
-                           num-vers
-                           num-templates
-                           (/ max-iris 2))
-       (iri/create-iri-vec prof-num
-                           ver-num
-                           pattern-num
-                           "pattern"
-                           num-profs
-                           num-vers
-                           num-patterns
-                           (/ max-iris 2)))
-      shuffle))
+  (let [{fst-pat-id :id :as first-pattern} (rand-nth pattern-vec)]
+    (loop [patterns [(assoc first-pattern :primary true)]
+           updated-pats (-> (reduce (fn [m pat] (assoc m (:id pat) pat))
+                                    {}
+                                    pattern-vec)
+                            (update fst-pat-id assoc :primary true))
+           trans-close {fst-pat-id #{fst-pat-id}}]
+      (if-some [{pat-id :id :as pattern} (first patterns)]
+        (let [tclose (get trans-close pat-id)]
+          (cond
+            (contains? pattern :sequence)
+            (let [seq-pats (->> (iri/create-same-version-iri-vec prof-num
+                                                                 ver-num
+                                                                 -1
+                                                                 "pattern"
+                                                                 num-patterns
+                                                                 max-iris)
+                                (filter #(not (contains? tclose %))))
+                  seq-all (->> seq-pats
+                               (concat (:sequence pattern))
+                               shuffle
+                               (take max-iris)
+                               vec)
+                  new-pat (assoc pattern :sequence seq-all)]
+              (recur (concat (rest patterns)
+                             (map (partial get updated-pats) seq-pats))
+                     (assoc updated-pats pat-id new-pat)
+                     (update-transitive-closure trans-close pat-id seq-pats)))
+            (contains? pattern :alternates)
+            (let [alt-pats (->> (iri/create-same-version-iri-vec prof-num
+                                                                 ver-num
+                                                                 -1
+                                                                 "pattern"
+                                                                 num-patterns
+                                                                 max-iris)
+                                (filter (fn [sub-pat-id]
+                                          (not (contains? tclose sub-pat-id))))
+                                (filter (fn [sub-pat-id]
+                                          (let [sub-pat (get updated-pats sub-pat-id)]
+                                            (not (or (contains? sub-pat :optional)
+                                                     (contains? sub-pat :zeroOrMore)))))))
+                  alt-all (->> alt-pats
+                               (concat (:alternates pattern))
+                               shuffle
+                               (take max-iris)
+                               vec)
+                  new-pat (assoc pattern :alternates alt-all)]
+              (recur (concat (rest patterns)
+                             (map (partial get updated-pats) alt-pats))
+                     (assoc updated-pats pat-id new-pat)
+                     (update-transitive-closure trans-close pat-id alt-pats)))
+            :else ; optional, oneOrMore, zeroOrMore
+            (if-some [iri (->> (iri/create-same-version-iri-vec prof-num
+                                                                ver-num
+                                                                -1
+                                                                "pattern"
+                                                                num-patterns
+                                                                1)
+                               (filter (fn [sub-pat-id]
+                                         (not (contains? tclose sub-pat-id))))
+                               first)]
+              (let [pat-kw  (-> pattern
+                                (select-keys [:optional :oneOrMore :zeroOrMore])
+                                keys
+                                first)
+                    new-pat (assoc pattern pat-kw iri)]
+                (recur (conj (rest patterns)
+                             (get updated-pats iri))
+                       (assoc updated-pats pat-id new-pat)
+                       (update-transitive-closure trans-close pat-id #{iri})))
+              (recur (rest patterns)
+                     updated-pats
+                     trans-close))))
+        (vec (vals updated-pats))))))
 
 (defmethod generate-object "Pattern"
   [prof-num
@@ -60,52 +145,54 @@
    pattern-type
    {num-profs :num-profiles
     num-vers  :num-versions
-    num-pats  :num-patterns
     num-temps :num-statement-templates
     max-iris  :max-iris}]
   (let [id       (iri/create-iri prof-num ver-num "pattern" pattern-num)
         inscheme (iri/create-iri prof-num ver-num)
         pat-kw   (rand-nth [:sequence :alternates :optional :oneOrMore :zeroOrMore])
-        iris     (condp #(contains? %1 %2) pat-kw
-                   #{:optional :oneOrMore :zeroOrMore}
-                   (loop []
-                     (if-some [iri (generate-pattern-iri-scalar prof-num
-                                                                ver-num
-                                                                pattern-num
-                                                                num-profs
-                                                                num-vers
-                                                                num-temps
-                                                                num-pats)]
-                       iri
-                       (recur)))
-                   #{:sequence :alternates}
-                   (loop []
-                     (let [?iris (generate-pattern-iri-coll prof-num
-                                                            ver-num
-                                                            pattern-num
-                                                            num-profs
-                                                            num-vers
-                                                            num-temps
-                                                            num-pats
-                                                            max-iris)]
-                       (if (and ?iris (<= 2 (count ?iris)))
-                         ?iris
-                         (recur)))))]
-    {:id         id
-     :inScheme   inscheme
-     :type       pattern-type
-     :prefLabel  {:en-US (format "Pattern %d" pattern-num)}
-     :definition {:en-US (format "Pattern Number %d" pattern-num)}
-     pat-kw      iris}))
+        pat-base {:id         id
+                  :inScheme   inscheme
+                  :type       pattern-type
+                  :prefLabel  {:en-US (format "Pattern %d" pattern-num)}
+                  :definition {:en-US (format "Pattern Number %d" pattern-num)}}]
+    (condp #(contains? %1 %2) pat-kw
+      #{:optional :oneOrMore :zeroOrMore}
+      (init-scalar-pattern pat-base pat-kw num-profs num-vers num-temps)
+      #{:sequence :alternates}
+      (init-coll-pattern pat-base pat-kw num-profs num-vers num-temps max-iris))))
+
+(comment
+  (generate-object 0
+                   0
+                   0
+                   "Pattern"
+                   {:num-profiles 2
+                    :num-versions 2
+                    :num-statement-templates 2
+                    :max-iris 5}))
 
 (defn generate-patterns
-  "Generate a vector of patterns, or `nil` if empty."
-  [profile-num version-num {:keys [num-patterns] :as args}]
-  (not-empty
-   (mapv (fn [pattern-num]
-           (generate-object profile-num
-                            version-num
-                            pattern-num
-                            "Pattern"
-                            args))
-         (range num-patterns))))
+  [profile-num version-num {:keys [num-patterns max-iris] :as args}]
+  (let [patterns  (map (fn [pattern-num]
+                         (generate-object profile-num
+                                          version-num
+                                          pattern-num
+                                          "Pattern"
+                                          args))
+                       (range num-patterns))
+        patterns*  (add-patterns patterns
+                                 profile-num
+                                 version-num
+                                 num-patterns
+                                 max-iris)]
+    patterns*))
+
+(comment
+  (generate-patterns
+   0
+   0
+   {:num-profiles 2
+    :num-versions 2
+    :num-statement-templates 10
+    :num-patterns 10
+    :max-iris 5}))

--- a/src/main/com/yetanalytics/poly/profile/pattern.cljc
+++ b/src/main/com/yetanalytics/poly/profile/pattern.cljc
@@ -60,12 +60,12 @@
    num-vers
    num-templates]
   (assoc pattern-base
-         pattern-kw (first (iri/create-iri-vec "template"
-                                               num-profs
-                                               num-vers
-                                               num-templates
-                                               1
-                                               1))))
+         pattern-kw (first (iri/create-nondistinct-iri-vec "template"
+                                                           num-profs
+                                                           num-vers
+                                                           num-templates
+                                                           1
+                                                           1))))
 
 (defn- init-coll-pattern
   [pattern-base
@@ -75,12 +75,12 @@
    num-templates
    max-iris]
   (assoc pattern-base
-         pattern-kw (iri/create-iri-vec "template"
-                                        num-profs
-                                        num-vers
-                                        num-templates
-                                        max-iris
-                                        2)))
+         pattern-kw (iri/create-nondistinct-iri-vec "template"
+                                                    num-profs
+                                                    num-vers
+                                                    num-templates
+                                                    max-iris
+                                                    2)))
 
 (defn- add-patterns
   "Add a single Pattern DAG to `pattern-coll` by designating a random Pattern

--- a/src/main/com/yetanalytics/poly/profile/utils/iri.cljc
+++ b/src/main/com/yetanalytics/poly/profile/utils/iri.cljc
@@ -66,6 +66,8 @@
                        num-pairs)]
      (->> iri-coll vec not-empty))))
 
+;; Used for Patterns, which require `min-iris` and in general do not care about
+;; IRI distinctiveness.
 (defn create-nondistinct-iri-vec
   "Similar to `create-iri-vec`, but with two differences:
    - A `min-iris` arg is required to set the minimum number of IRIs in the coll.

--- a/src/main/com/yetanalytics/poly/profile/utils/iri.cljc
+++ b/src/main/com/yetanalytics/poly/profile/utils/iri.cljc
@@ -23,38 +23,6 @@
            object-slug
            object-num)))
 
-(defn- create-iri-vec*
-  ([object-slug num-profiles num-versions num-objects num-iris]
-   (let [num-pairs (->> (repeatedly num-iris (fn [] [(rand-int num-profiles)
-                                                     (rand-int num-versions)
-                                                     (rand-int num-objects)]))
-                        distinct)
-         iri-coll  (map (fn [[pnum vnum onum]]
-                          (format "http://poly.profile/profile-%d/v%d/%s-%d"
-                                  pnum
-                                  vnum
-                                  object-slug
-                                  onum))
-                        num-pairs)]
-     (->> iri-coll vec not-empty)))
-  ([profile-num version-num object-num object-slug num-profiles num-versions num-objects num-iris]
-   (let [num-pairs (->> (repeatedly num-iris (fn [] [(rand-int num-profiles)
-                                                     (rand-int num-versions)
-                                                     (rand-int num-objects)]))
-                        (filter (fn [[pnum vnum onum]]
-                                  (or (not= profile-num pnum)
-                                      (not= version-num vnum)
-                                      (not= object-num onum))))
-                        distinct)
-         iri-coll  (map (fn [[pnum vnum onum]]
-                          (format "http://poly.profile/profile-%d/v%d/%s-%d"
-                                  pnum
-                                  vnum
-                                  object-slug
-                                  onum))
-                        num-pairs)]
-     (->> iri-coll vec not-empty))))
-
 (defn create-iri-vec
   "Create a vector of IRIs (with length limited by `max-iris`) of the form
    ```
@@ -64,42 +32,58 @@
    `num-profiles`, `num-versions`, and `num-objects` (exclusive), respectively.
    If `profile-num`, `version-num,` and `object-num` are provided, then the
    IRI that contains all three of these values is never returned, in order to
-   prevent self-loops. If `min-iris` is provided, that provides an (inclusive)
-   minumum number of IRIs in the returned vector."
+   prevent self-loops."
   ([object-slug num-profiles num-versions num-objects max-iris]
-   (let [num-iris (rand-int (inc max-iris))]
-     (create-iri-vec* object-slug
-                      num-profiles
-                      num-versions
-                      num-objects
-                      num-iris)))
+   (let [num-iris (rand-int (inc max-iris))
+         num-pairs (->> (repeatedly num-iris (fn [] [(rand-int num-profiles)
+                                                     (rand-int num-versions)
+                                                     (rand-int num-objects)]))
+                        distinct)
+         iri-coll (map (fn [[pnum vnum onum]]
+                         (format "http://poly.profile/profile-%d/v%d/%s-%d"
+                                 pnum
+                                 vnum
+                                 object-slug
+                                 onum))
+                       num-pairs)]
+     (->> iri-coll vec not-empty)))
   ([profile-num version-num object-num object-slug num-profiles num-versions num-objects max-iris]
-   (let [num-iris (rand-int (inc max-iris))]
-     (create-iri-vec* profile-num
-                      version-num
-                      object-num
-                      object-slug
-                      num-profiles
-                      num-versions
-                      num-objects
-                      num-iris)))
-  ([object-slug num-profiles num-versions num-objects max-iris min-iris]
-   (let [num-iris (+ min-iris (rand-int (- (inc max-iris) min-iris)))]
-     (create-iri-vec* object-slug
-                      num-profiles
-                      num-versions
-                      num-objects
-                      num-iris)))
-  ([profile-num version-num object-num object-slug num-profiles num-versions num-objects max-iris min-iris]
-   (let [num-iris (+ min-iris (rand-int (- (inc max-iris) min-iris)))]
-     (create-iri-vec* profile-num
-                      version-num
-                      object-num
-                      object-slug
-                      num-profiles
-                      num-versions
-                      num-objects
-                      num-iris))))
+   (let [num-iris (rand-int (inc max-iris))
+         num-pairs (->> (repeatedly num-iris (fn [] [(rand-int num-profiles)
+                                                     (rand-int num-versions)
+                                                     (rand-int num-objects)]))
+                        (filter (fn [[pnum vnum onum]]
+                                  (or (not= profile-num pnum)
+                                      (not= version-num vnum)
+                                      (not= object-num onum))))
+                        distinct)
+         iri-coll (map (fn [[pnum vnum onum]]
+                         (format "http://poly.profile/profile-%d/v%d/%s-%d"
+                                 pnum
+                                 vnum
+                                 object-slug
+                                 onum))
+                       num-pairs)]
+     (->> iri-coll vec not-empty))))
+
+(defn create-nondistinct-iri-vec
+  "Similar to `create-iri-vec`, but with two differences:
+   - A `min-iris` arg is required to set the minimum number of IRIs in the coll.
+   - Repeated IRIs are not removed."
+  [object-slug num-profiles num-versions num-objects min-iris max-iris]
+  (let [num-iris  (+ min-iris (rand-int (- (inc max-iris) min-iris)))
+        num-pairs (repeatedly num-iris (fn [] [(rand-int num-profiles)
+                                               (rand-int num-versions)
+                                               (rand-int num-objects)]))
+
+        iri-coll  (map (fn [[pnum vnum onum]]
+                         (format "http://poly.profile/profile-%d/v%d/%s-%d"
+                                 pnum
+                                 vnum
+                                 object-slug
+                                 onum))
+                       num-pairs)]
+    (->> iri-coll vec not-empty)))
 
 (defn create-same-version-iri-vec
   "Create a vector of IRIs (with length limited by `max-iris`) of the form

--- a/src/main/com/yetanalytics/poly/profile/utils/iri.cljc
+++ b/src/main/com/yetanalytics/poly/profile/utils/iri.cljc
@@ -23,19 +23,9 @@
            object-slug
            object-num)))
 
-(defn create-iri-vec
-  "Create a vector of IRIs (with length limited by `max-iris`) of the form
-   ```
-   http://poly.profile/profile-[pnum]/v[vnum]/[object-slug]-[onum]
-   ```
-   where `pnum`, `vnum`, `onum` have min value 0 (inclusive) and max value
-   `num-profiles`, `num-versions`, and `num-objects` (exclusive), respectively.
-   If `profile-num`, `version-num,` and `object-num` are provided, then the
-   IRI that contains all three of these values is never returned, in order to
-   prevent self-loops."
-  ([object-slug num-profiles num-versions num-objects max-iris]
-   (let [num-iris  (rand-int (inc max-iris))
-         num-pairs (->> (repeatedly num-iris (fn [] [(rand-int num-profiles)
+(defn- create-iri-vec*
+  ([object-slug num-profiles num-versions num-objects num-iris]
+   (let [num-pairs (->> (repeatedly num-iris (fn [] [(rand-int num-profiles)
                                                      (rand-int num-versions)
                                                      (rand-int num-objects)]))
                         distinct)
@@ -47,9 +37,8 @@
                                   onum))
                         num-pairs)]
      (->> iri-coll vec not-empty)))
-  ([profile-num version-num object-num object-slug num-profiles num-versions num-objects max-iris]
-   (let [num-iris  (rand-int (inc max-iris))
-         num-pairs (->> (repeatedly num-iris (fn [] [(rand-int num-profiles)
+  ([profile-num version-num object-num object-slug num-profiles num-versions num-objects num-iris]
+   (let [num-pairs (->> (repeatedly num-iris (fn [] [(rand-int num-profiles)
                                                      (rand-int num-versions)
                                                      (rand-int num-objects)]))
                         (filter (fn [[pnum vnum onum]]
@@ -65,6 +54,52 @@
                                   onum))
                         num-pairs)]
      (->> iri-coll vec not-empty))))
+
+(defn create-iri-vec
+  "Create a vector of IRIs (with length limited by `max-iris`) of the form
+   ```
+   http://poly.profile/profile-[pnum]/v[vnum]/[object-slug]-[onum]
+   ```
+   where `pnum`, `vnum`, `onum` have min value 0 (inclusive) and max value
+   `num-profiles`, `num-versions`, and `num-objects` (exclusive), respectively.
+   If `profile-num`, `version-num,` and `object-num` are provided, then the
+   IRI that contains all three of these values is never returned, in order to
+   prevent self-loops. If `min-iris` is provided, that provides an (inclusive)
+   minumum number of IRIs in the returned vector."
+  ([object-slug num-profiles num-versions num-objects max-iris]
+   (let [num-iris (rand-int (inc max-iris))]
+     (create-iri-vec* object-slug
+                      num-profiles
+                      num-versions
+                      num-objects
+                      num-iris)))
+  ([profile-num version-num object-num object-slug num-profiles num-versions num-objects max-iris]
+   (let [num-iris (rand-int (inc max-iris))]
+     (create-iri-vec* profile-num
+                      version-num
+                      object-num
+                      object-slug
+                      num-profiles
+                      num-versions
+                      num-objects
+                      num-iris)))
+  ([object-slug num-profiles num-versions num-objects max-iris min-iris]
+   (let [num-iris (+ min-iris (rand-int (- (inc max-iris) min-iris)))]
+     (create-iri-vec* object-slug
+                      num-profiles
+                      num-versions
+                      num-objects
+                      num-iris)))
+  ([profile-num version-num object-num object-slug num-profiles num-versions num-objects max-iris min-iris]
+   (let [num-iris (+ min-iris (rand-int (- (inc max-iris) min-iris)))]
+     (create-iri-vec* profile-num
+                      version-num
+                      object-num
+                      object-slug
+                      num-profiles
+                      num-versions
+                      num-objects
+                      num-iris))))
 
 (defn create-same-version-iri-vec
   "Create a vector of IRIs (with length limited by `max-iris`) of the form

--- a/src/test/com/yetanalytics/poly/profile_test.cljc
+++ b/src/test/com/yetanalytics/poly/profile_test.cljc
@@ -85,7 +85,9 @@
               ;; (and fix any Pan bugs while at it).
               (pan/validate-profile-coll :syntax? true
                                          :ids? true
-                                         :context? true)
+                                         :context? true
+                                        ;;  :relations? true
+                                         )
               nil?))))
   (testing "Generate a seq of empty profiles"
     (let [prof-lazy-seq (poly/generate-profile-seq {:num-verbs 0
@@ -109,10 +111,3 @@
   (testing "Generate an empty seq of profiles"
     (let [empty-seq (poly/generate-profile-seq {:num-profiles 0})]
       (is (empty? empty-seq)))))
-
-(comment
-  (def prof-seq (vec (poly/generate-profile-seq {:num-profiles 2})))
-  (pan/validate-profile-coll prof-seq
-                             :syntax? false
-                             :relations? true
-                             :result :print))

--- a/src/test/com/yetanalytics/poly/profile_test.cljc
+++ b/src/test/com/yetanalytics/poly/profile_test.cljc
@@ -77,17 +77,10 @@
              (count prof-lazy-seq)))
       (is (-> prof-lazy-seq
               vec
-              ;; Don't set `:relations?` to true (despite being fairly
-              ;; important) since polyprofile doesn't account for specialized
-              ;; Pattern relation specs
-
-              ;; TODO: Ensure that all Pattern relation specs are followed
-              ;; (and fix any Pan bugs while at it).
               (pan/validate-profile-coll :syntax? true
                                          :ids? true
                                          :context? true
-                                        ;;  :relations? true
-                                         )
+                                         :relations? true)
               nil?))))
   (testing "Generate a seq of empty profiles"
     (let [prof-lazy-seq (poly/generate-profile-seq {:num-verbs 0


### PR DESCRIPTION
Remove the following potential errors from pattern generation:
- cyclic patterns
- `alternates` that contain `optional` or `zeroOrMore` sub-patterns
- `sequence` and `alternates` that contain only one sub-pattern

To simplify things, Patterns now only point to sub-Patterns within the same Profile version (though Templates can still be from any Profile).

Also update the Pan SHA to remove Pan bugs from occurring during test time.